### PR TITLE
chore: dynamic new unstable release loading is working

### DIFF
--- a/pages/download/content.mdx
+++ b/pages/download/content.mdx
@@ -3,6 +3,7 @@ title: Operatsion Tizimni Yuklash
 description: Ushbu sahifada siz Xinux tomonidan yaratilgan operatsion tizimni yuklab olsangiz bo'ladi
 ---
 
+export const meta = {}
 import { Cards, Card } from 'nextra/components'
 
 # Xinux Operatsion Tizimi
@@ -15,6 +16,8 @@ Operatsion tizim ikki turda taqdim etiladi, stabil va nostabil. Nostabil shakl s
 ## Yuklash
 
 <Cards>
-  <Card title="Nostabil (25.05)" href="https://cdn.xinux.uz/latest/nixos-25.05.20251026.78e34d1-x86_64-linux.iso" />
+  <Card title="Nostabil (25.11)" href={props.latestUrl}>
+    {props.latestName}
+  </Card>
   <Card title="Stabil (25.11) [Tez kunda]" href="https://cdn.xinux.uz/releases/" />
 </Cards>

--- a/pages/download/index.js
+++ b/pages/download/index.js
@@ -1,0 +1,21 @@
+import Page from "./content.mdx";
+
+export async function getStaticProps() {
+    const res = await fetch("https://cdn.xinux.uz/latest/");
+    const data = await res.json();
+
+    const latest = data
+        .filter((i) => i.type === "file")
+        .sort((a, b) => new Date(b.mtime) - new Date(a.mtime))[0];
+
+    return {
+        props: {
+            latestName: latest.name,
+            latestUrl: `https://cdn.xinux.uz/latest/${latest.name}`,
+        },
+    };
+}
+
+export default function Wrapper(props) {
+    return <Page {...props} />;
+}


### PR DESCRIPTION
## Latest Download Fetch

* **Endpoint:** `https://cdn.xinux.uz/latest/`
* **Logic:** Fetch files $\rightarrow$ Sort by `mtime` $\rightarrow$ Select newest.
* **Props to Page:** `name` and URL of the latest file.
* **Status:** Logic implemented. **Styling (CSS) broken/missing.**